### PR TITLE
Handle API paths with or without initial slash

### DIFF
--- a/lib/wepay.rb
+++ b/lib/wepay.rb
@@ -35,7 +35,7 @@ class WePay
 	# make a call to the WePay API
 	def call(call, access_token = false, params = false)
 		# get the url
-		url = URI.parse(@api_endpoint + call)
+		url = URI.parse(@api_endpoint + (call[0,1] == '/' ? call : "/#{ call }")
 		# construct the call data and access token
 		call = Net::HTTP::Post.new(url.path, initheader = {'Content-Type' =>'application/json', 'User-Agent' => 'WePay Ruby SDK'})
 		if params

--- a/lib/wepay.rb
+++ b/lib/wepay.rb
@@ -35,7 +35,7 @@ class WePay
 	# make a call to the WePay API
 	def call(call, access_token = false, params = false)
 		# get the url
-		url = URI.parse(@api_endpoint + (call[0,1] == '/' ? call : "/#{ call }")
+		url = URI.parse(@api_endpoint + (call[0,1] == '/' ? call : "/#{ call }"))
 		# construct the call data and access token
 		call = Net::HTTP::Post.new(url.path, initheader = {'Content-Type' =>'application/json', 'User-Agent' => 'WePay Ruby SDK'})
 		if params


### PR DESCRIPTION
The API 404s if the gem is called without a leading slash, as in `user/register` rather than `/user/register`. In the spirit of making our developers' lives easier, I've updated the gem to handle both formats for the path endpoint.